### PR TITLE
Revert "vala 0.32: use new operator to create new objects"

### DIFF
--- a/libkkc/key-event.vala
+++ b/libkkc/key-event.vala
@@ -148,7 +148,7 @@ namespace Kkc {
                     throw new KeyEventFormatError.PARSE_FAILED (
                         "unknown keyval %s", _name);
             }
-            new from_x_event (_keyval, 0, _modifiers);
+            from_x_event (_keyval, 0, _modifiers);
         }
 
         /**


### PR DESCRIPTION
This reverts commit 8b5af2f6bc891e726fcb0316c23af2cb67787741, which
causes test failures with Vala 0.34:
https://travis-ci.org/ueno/libkkc/builds/215564993