### PR TITLE
build: Fix compile error with Vala 0.36

### DIFF
--- a/libkkc/key-event.vala
+++ b/libkkc/key-event.vala
@@ -148,7 +148,7 @@ namespace Kkc {
                     throw new KeyEventFormatError.PARSE_FAILED (
                         "unknown keyval %s", _name);
             }
-            from_x_event (_keyval, 0, _modifiers);
+            this.from_x_event (_keyval, 0, _modifiers);
         }
 
         /**


### PR DESCRIPTION
With this commit: https://git.gnome.org/browse/vala/commit/?id=73b9e4b4
Vala introduced a stricter checks for constructor chain-ups.