### PR TITLE
public something to make vala 0.38 happy

### DIFF
--- a/libkkc/encoding.vala
+++ b/libkkc/encoding.vala
@@ -18,7 +18,7 @@
 namespace Kkc {
     // XXX: we use Vala string to represent byte array, assuming that
     // it does not contain null element
-    class EncodingConverter : Object, Initable {
+    public class EncodingConverter : Object, Initable {
         const int BUFSIZ = 4096;
         const string INTERNAL_ENCODING = "UTF-8";
 
@@ -67,7 +67,7 @@ namespace Kkc {
             return true;
         }
 
-        internal EncodingConverter (string encoding) throws Error {
+        public EncodingConverter (string encoding) throws Error {
             Object (encoding: encoding);
             init (null);
         }

--- a/libkkc/expression.vala
+++ b/libkkc/expression.vala
@@ -191,7 +191,7 @@ namespace Kkc {
         }
     }
 
-    abstract class Expression : Object {
+    public abstract class Expression : Object {
         public static string eval (string text) {
             if (text.has_prefix ("(")) {
                 var reader = new ExpressionReader ();

--- a/libkkc/key-event-filter.vala
+++ b/libkkc/key-event-filter.vala
@@ -52,7 +52,7 @@ namespace Kkc {
      *
      * @see Rule
      */
-    class SimpleKeyEventFilter : KeyEventFilter {
+    public class SimpleKeyEventFilter : KeyEventFilter {
         const uint[] modifier_keyvals = {
             Keysyms.Shift_L,
             Keysyms.Shift_R,
@@ -90,7 +90,7 @@ namespace Kkc {
      *
      * @see Rule
      */
-    class KanaKeyEventFilter : SimpleKeyEventFilter {
+     public class KanaKeyEventFilter : SimpleKeyEventFilter {
         /**
          * {@inheritDoc}
          */

--- a/libkkc/numeric-template.vala
+++ b/libkkc/numeric-template.vala
@@ -18,7 +18,7 @@
 using Gee;
 
 namespace Kkc {
-    class NumericTemplate : Object, Template {
+    public class NumericTemplate : Object, Template {
         ArrayList<int> numerics = new ArrayList<int> ();
 
         public string source { get; construct set; }

--- a/libkkc/state.vala
+++ b/libkkc/state.vala
@@ -24,7 +24,7 @@ namespace Kkc {
     const double DECODER_MIN_PATH_COST = -3.0;
     const int DECODER_NBEST = 20;
 
-    class State : Object {
+    public class State : Object {
         internal Type handler_type;
         InputMode _input_mode;
         [CCode(notify = false)]
@@ -211,7 +211,7 @@ namespace Kkc {
             return keymap.lookup_key (key);
         }
 
-        internal State (LanguageModel model, DictionaryList dictionaries) {
+        public State (LanguageModel model, DictionaryList dictionaries) {
             this.model = model;
             this.decoder = Decoder.create (model);
             this.dictionaries = dictionaries;

--- a/libkkc/template.vala
+++ b/libkkc/template.vala
@@ -16,13 +16,13 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 namespace Kkc {
-    internal interface Template : Object {
+    public interface Template : Object {
         public abstract string source { get; construct set; }
         public abstract bool okuri { get; construct set; }
         public abstract string expand (string text);
     }
 
-    class SimpleTemplate : Object, Template {
+    public class SimpleTemplate : Object, Template {
         public string source { get; construct set; }
         public bool okuri { get; construct set; }
 
@@ -36,7 +36,7 @@ namespace Kkc {
         }
     }
 
-    class OkuriganaTemplate : Object, Template {
+    public class OkuriganaTemplate : Object, Template {
         public string source { get; construct set; }
         public bool okuri { get; construct set; }
 

--- a/libkkc/utils.vala
+++ b/libkkc/utils.vala
@@ -101,7 +101,7 @@ namespace Kkc {
         }
     }
 
-    abstract class KeyEventUtils : Object {
+    public abstract class KeyEventUtils : Object {
         static KeysymEntry *bsearch_keysyms (
             KeysymEntry *memory,
             long start_offset,


### PR DESCRIPTION
On openSUSE Tumbleweed whose vala is 0.38, libkkc builds failed with ‘unknown type name Kkc.State do you mean Kkc.Rule’ and ‘implicit declaration of function kkc_state_new’.

This can be resolved by making those warned classes public.

But, I know little of vala so don’t know if it’s the correct way

And I cannot find the exact vala version that caused such failures.

It may be 0.36 ~ 0.38 

So please merge carefully :-D