### PR TITLE
build: Fix no public abstract class with vala 0.45.3

### DIFF
--- a/libkkc/language-model.vala
+++ b/libkkc/language-model.vala
@@ -44,7 +44,8 @@ namespace Kkc {
         }
 
         public LanguageModelMetadata (string name, string filename) throws Error {
-            base (name, filename);
+            Object (name: name, filename: filename);
+            init (null);
         }
 
         public override bool parse (Json.Object object) throws Error {
@@ -100,11 +101,6 @@ namespace Kkc {
         public abstract Collection<LanguageModelEntry?> entries (string input);
         public abstract new LanguageModelEntry? @get (string input,
                                                       string output);
-
-        public LanguageModel (LanguageModelMetadata metadata) throws Error {
-            Object (metadata: metadata);
-            init (null);
-        }
 
         public abstract bool parse () throws Error;
 

--- a/libkkc/metadata-file.vala
+++ b/libkkc/metadata-file.vala
@@ -43,11 +43,6 @@ namespace Kkc {
          */
         public string filename { get; construct set; }
 
-        public MetadataFile (string name, string filename) throws Error {
-            Object (name: name, filename: filename);
-            init (null);
-        }
-
         public abstract bool parse (Json.Object object) throws Error;
 
         public bool init (GLib.Cancellable? cancellable = null) throws Error {

--- a/libkkc/rule.vala
+++ b/libkkc/rule.vala
@@ -171,7 +171,8 @@ namespace Kkc {
         }
 
         public RuleMetadata (string name, string filename) throws Error {
-            base (name, filename);
+            Object (name: name, filename: filename);
+            init (null);
         }
 
         public override bool parse (Json.Object object) throws Error {

--- a/libkkc/sorted-bigram-language-model.vala
+++ b/libkkc/sorted-bigram-language-model.vala
@@ -209,7 +209,8 @@ namespace Kkc {
         }
 
         public SortedBigramLanguageModel (LanguageModelMetadata metadata) throws Error {
-            base (metadata);
+            Object (metadata: metadata);
+            init (null);
         }
     }
 }

--- a/libkkc/text-bigram-language-model.vala
+++ b/libkkc/text-bigram-language-model.vala
@@ -187,7 +187,8 @@ namespace Kkc {
         }
 
         public TextBigramLanguageModel (LanguageModelMetadata metadata) throws Error {
-            base (metadata);
+            Object (metadata: metadata);
+            init (null);
         }
     }
 }

--- a/tests/metadata-file.vala
+++ b/tests/metadata-file.vala
@@ -1,6 +1,7 @@
 class EmptyMetadata : Kkc.MetadataFile {
     public EmptyMetadata (string name, string filename) throws Error {
-        base (name, filename);
+        Object (name: name, filename: filename);
+        init (null);
     }
 
     public override bool parse (Json.Object object) throws Error {


### PR DESCRIPTION
Creation method of abstract class cannot be public with the latest vala

https://github.com/ueno/libkkc/issues/22