### PR TITLE
build: Declare creation methods of abstract classes as protected

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ language: c
 env:
   - BUILD_OPTS="--prefix=/usr --libdir=/usr/lib64"
   - BUILD_OPTS="--prefix=/usr --libdir=/usr/lib64 --enable-docs" DOCS=yes EXTRA_PKGS="gtk-doc valadoc valadoc-devel"
-  - BUILD_OPTS="--prefix=/usr --libdir=/usr/lib64 --enable-code-coverage" COVERAGE=yes EXTRA_PKGS="python-pip"
+  - BUILD_OPTS="--prefix=/usr --libdir=/usr/lib64 --enable-code-coverage PYTHON=python3" COVERAGE=yes EXTRA_PKGS="python3-marisa python3-pip"
   - BUILD_OPTS="--prefix=/usr --libdir=/usr/lib64 CFLAGS='-fsanitize=address -g -fno-common -U_FORTIFY_SOURCE' CXXFLAGS='-fsanitize=address -g -fno-common -U_FORTIFY_SOURCE' LDFLAGS='-fsanitize=address -g -fno-common -U_FORTIFY_SOURCE' LIBS='-ldl -lpthread'" EXTRA_PKGS="libasan"
   - BUILD_OPTS="--prefix=/usr --libdir=/usr/lib64 CFLAGS='-fsanitize=undefined -g -fno-common -U_FORTIFY_SOURCE' CXXFLAGS='-fsanitize=undefined -g -fno-common -U_FORTIFY_SOURCE' LDFLAGS='-fsanitize=undefined -g -fno-common -U_FORTIFY_SOURCE' LIBS='-ldl -lpthread'" EXTRA_PKGS="libubsan"
 

--- a/configure.ac
+++ b/configure.ac
@@ -125,7 +125,7 @@ VALADOC_REQUIRED=0.3.1
 have_valadoc=no
 if test x$enable_docs = xyes; then
   # make sure the library is new enough and the program exists
-  PKG_CHECK_MODULES([VALADOC], [valadoc-0.40 >= $VALADOC_REQUIRED])
+  PKG_CHECK_MODULES([VALADOC], [valadoc-0.44 >= $VALADOC_REQUIRED])
   AC_PATH_PROG([VALADOC], [valadoc], [:])
   AS_IF([test "$VALADOC" != :], have_valadoc=yes)
 fi

--- a/libkkc/language-model.vala
+++ b/libkkc/language-model.vala
@@ -101,7 +101,7 @@ namespace Kkc {
         public abstract new LanguageModelEntry? @get (string input,
                                                       string output);
 
-        public LanguageModel (LanguageModelMetadata metadata) throws Error {
+        protected LanguageModel (LanguageModelMetadata metadata) throws Error {
             Object (metadata: metadata);
             init (null);
         }

--- a/libkkc/metadata-file.vala
+++ b/libkkc/metadata-file.vala
@@ -43,7 +43,7 @@ namespace Kkc {
          */
         public string filename { get; construct set; }
 
-        public MetadataFile (string name, string filename) throws Error {
+        protected MetadataFile (string name, string filename) throws Error {
             Object (name: name, filename: filename);
             init (null);
         }

--- a/tests/lib/test-case.vala
+++ b/tests/lib/test-case.vala
@@ -29,7 +29,7 @@ public abstract class Kkc.TestCase : Object
 
   public delegate void TestMethod ();
 
-  public TestCase (string name)
+  protected TestCase (string name)
     {
       this._suite = new GLib.TestSuite (name);
     }


### PR DESCRIPTION
Public creation methods of abstract classes are no longer allowed since 0.45.1:
https://gitlab.gnome.org/GNOME/vala/commit/9365176e3f4fab737112e957f38c128752c8b504

Suggested by Rico Tzschichholz.

Fixes #22.