### PR TITLE
Use LIBKKC_CFLAGS and LIBKKC_LIBS in tests/lib/Makefile.am

### DIFF
--- a/tests/lib/Makefile.am
+++ b/tests/lib/Makefile.am
@@ -4,9 +4,7 @@ libkkc_test_la_SOURCES = test-case.vala test-utils.vala
 
 libkkc_test_la_CFLAGS =				\
 	$(AM_CFLAGS)				\
-	$(GIO_CFLAGS)				\
-	$(GEE_CFLAGS)				\
-	$(JSON_GLIB_CFLAGS)			\
+	$(LIBKKC_CFLAGS)				\
 	$(NULL)
 
 libkkc_test_la_CPPFLAGS =			\
@@ -18,9 +16,7 @@ libkkc_test_la_CPPFLAGS =			\
 libkkc_test_la_LIBADD =					\
 	$(AM_LIBADD)					\
 	$(top_builddir)/libkkc/libkkc-internals.la	\
-	$(GIO_LIBS)					\
-	$(GEE_LIBS)					\
-	$(JSON_GLIB_LIBS)				\
+	$(LIBKKC_LIBS)					\
 	$(NULL)
 
 libkkc_test_la_VALAFLAGS =			\


### PR DESCRIPTION
GIO_CFLAGS, GEE_CFLAGS and JSON_GLIB_CFLAGS are defined as LIBKKC_CFLAGS in configure.ac.
GIO_LIBS, GEE_LIBS and JSON_GLIB_LIBS are defined as LIBKKC_LIBS, too.

No functional changes, and just simplify the Makefile.am.