### PR TITLE
Ignore files under the tests directory

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -52,6 +52,9 @@ GITIGNOREFILES =							\
 	po/remove-potcdate.sin						\
 	po/stamp-po							\
 	test-driver							\
+	tests/\*.log							\
+	tests/\*.trs							\
+	tests/test-user-\*						\
 	$(NULL)
 
 distclean-local:


### PR DESCRIPTION
I believe *.log and *.trs files under the tests directory could be ignored by .gitignore.
tests/test-user-* is the same.
This pull request solves many "Untracked files" after the `make check`.