### PR TITLE
Add enum NONE case to switch

### DIFF
--- a/libkkc/user-sentence-dictionary.vala
+++ b/libkkc/user-sentence-dictionary.vala
@@ -94,6 +94,8 @@ namespace Kkc {
                 }
 
                 switch (state) {
+                case UserSentenceState.NONE:
+                    break;
                 case UserSentenceState.CONSTRAINT:
                     var numbers = new ArrayList<int> ();
                     var strv = candidates_str.slice (1, -1).split (",");


### PR DESCRIPTION
This suppress warning below.
"warning: Switch does not handle `NONE' of enum `Kkc.UserSentenceDictionary.UserSentenceState'"