### PR TITLE
Return false rather than null in boolean function

### DIFF
--- a/libkkc/system-segment-dictionary.vala
+++ b/libkkc/system-segment-dictionary.vala
@@ -70,7 +70,7 @@ namespace Kkc {
         // Skip until the first occurrence of line.  This moves offset
         // at the beginning of the next line.
         bool read_until (ref long offset, string line) {
-            return_val_if_fail (offset < mmap.get_length (), null);
+            return_val_if_fail (offset < mmap.get_length (), false);
             while (offset + line.length < mmap.get_length ()) {
                 char *p = ((char *)mmap.get_contents () + offset);
                 if (*p == '\n' &&


### PR DESCRIPTION
This suppress the warning below.
warning: returning ‘void *’ from a function with return type ‘gboolean’ {aka ‘int’} makes integer from pointer without a cast [-Wint-conversion]

Pointed out by @ricotz in #38