### PR TITLE
Use ".keys" for "in" operator with Gee.Map

### DIFF
--- a/libkkc/candidate-list.vala
+++ b/libkkc/candidate-list.vala
@@ -90,11 +90,11 @@ namespace Kkc {
         }
 
         internal bool contains (Candidate candidate) {
-            return candidate.output in seen;
+            return candidate.output in seen.keys;
         }
 
         internal bool add (Candidate candidate) {
-            if (candidate.output in seen) {
+            if (candidate.output in seen.keys) {
                 var c = seen.get (candidate.output);
                 // If the given candidate has annotation and the
                 // existing one doesn't, copy it.


### PR DESCRIPTION
This suppress warnings below.
candidate-list.vala:93.20-93.43: warning: `Gee.Map.contains' is deprecated. Use Map.has_key
candidate-list.vala:97.17-97.40: warning: `Gee.Map.contains' is deprecated. Use Map.has_key

Referred to https://gitlab.gnome.org/GNOME/vala/-/issues/848