### PR TITLE
Use get_real_time instead of deprecated TimeVal

### DIFF
--- a/libkkc/nicola.vala
+++ b/libkkc/nicola.vala
@@ -33,7 +33,7 @@ namespace Kkc {
      */
     public class NicolaKeyEventFilter : KeyEventFilter {
         static int64 get_time () {
-            return get_real_time();
+            return get_monotonic_time();
         }
 
         public GetTime get_time_func = get_time;

--- a/libkkc/nicola.vala
+++ b/libkkc/nicola.vala
@@ -33,8 +33,7 @@ namespace Kkc {
      */
     public class NicolaKeyEventFilter : KeyEventFilter {
         static int64 get_time () {
-            var tv = TimeVal ();
-            return (((int64) tv.tv_sec) * 1000000) + tv.tv_usec;
+            return get_real_time();
         }
 
         public GetTime get_time_func = get_time;


### PR DESCRIPTION
Suppress these warnings.
nicola.vala:36.22-36.28: warning: `GLib.TimeVal' has been deprecated since 2.62
nicola.vala:36.17-36.18: warning: `GLib.TimeVal' has been deprecated since 2.62